### PR TITLE
Add serviceAccountName cli option

### DIFF
--- a/cli/cmd/data/target.go
+++ b/cli/cmd/data/target.go
@@ -9,19 +9,20 @@ import (
 )
 
 type TargetDetails struct {
-	Namespace       string
-	PodName         string
-	ContainerName   string
-	ContainerId     string
-	Event           api.ProfilingEvent
-	Duration        time.Duration
-	Id              string
-	FileName        string
-	Alpine          bool
-	DryRun          bool
-	Image           string
-	DockerPath      string
-	Language        api.ProgrammingLanguage
-	Pgrep           string
-	ImagePullSecret string
+	Namespace          string
+	PodName            string
+	ContainerName      string
+	ContainerId        string
+	Event              api.ProfilingEvent
+	Duration           time.Duration
+	Id                 string
+	FileName           string
+	Alpine             bool
+	DryRun             bool
+	Image              string
+	DockerPath         string
+	Language           api.ProgrammingLanguage
+	Pgrep              string
+	ImagePullSecret    string
+	ServiceAccountName string
 }

--- a/cli/cmd/kubernetes/job/bpf.go
+++ b/cli/cmd/kubernetes/job/bpf.go
@@ -122,5 +122,9 @@ func (b *bpfCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (string
 		},
 	}
 
+	if cfg.TargetConfig.ServiceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = cfg.TargetConfig.ServiceAccountName
+	}
+
 	return id, job, nil
 }

--- a/cli/cmd/kubernetes/job/jvm.go
+++ b/cli/cmd/kubernetes/job/jvm.go
@@ -103,6 +103,10 @@ func (c *jvmCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (string
 		},
 	}
 
+	if cfg.TargetConfig.ServiceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = cfg.TargetConfig.ServiceAccountName
+	}
+
 	return id, job, nil
 }
 

--- a/cli/cmd/kubernetes/job/python.go
+++ b/cli/cmd/kubernetes/job/python.go
@@ -114,5 +114,9 @@ func (p *pythonCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (str
 		},
 	}
 
+	if cfg.TargetConfig.ServiceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = cfg.TargetConfig.ServiceAccountName
+	}
+
 	return id, job, nil
 }

--- a/cli/cmd/kubernetes/job/ruby.go
+++ b/cli/cmd/kubernetes/job/ruby.go
@@ -108,5 +108,9 @@ func (r *rubyCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (strin
 		},
 	}
 
+	if cfg.TargetConfig.ServiceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = cfg.TargetConfig.ServiceAccountName
+	}
+
 	return id, job, nil
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -118,6 +118,7 @@ func NewFlameCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&jobDetails.LimitConfig.CPU, "cpu.limits", "", "CPU limits of the started profiling container")
 	cmd.Flags().StringVar(&jobDetails.LimitConfig.Memory, "mem.limits", "", "Memory limits of the started profiling container")
 	cmd.Flags().StringVar(&targetDetails.ImagePullSecret, "imagePullSecret", "", "imagePullSecret for agent docker image")
+	cmd.Flags().StringVar(&targetDetails.ServiceAccountName, "serviceAccountName", "", "serviceAccountName to be used for profiling container")
 
 	options.configFlags.AddFlags(cmd.Flags())
 


### PR DESCRIPTION
This PR adds a new cli option, `serviceAccountName`, useful when you want to run the flame job under a specific service account.

Resolves https://github.com/yahoo/kubectl-flame/issues/59

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
