### PR TITLE
Add target-namespace option

### DIFF
--- a/cli/cmd/data/job.go
+++ b/cli/cmd/data/job.go
@@ -15,6 +15,9 @@ type JobDetails struct {
 
 	// LimitConfig configures resource limits for the job that is started.
 	LimitConfig ResourceConfig
+
+	// Namespace specifies the namespace for job execution.
+	Namespace string
 }
 
 // ResourceConfig holds resource configuration for either requests or limits.

--- a/cli/cmd/kubernetes/job/bpf.go
+++ b/cli/cmd/kubernetes/job/bpf.go
@@ -43,7 +43,7 @@ func (b *bpfCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (string
 
 	commonMeta := metav1.ObjectMeta{
 		Name:      fmt.Sprintf("kubectl-flame-%s", id),
-		Namespace: cfg.TargetConfig.Namespace,
+		Namespace: cfg.JobConfig.Namespace,
 		Labels: map[string]string{
 			"kubectl-flame/id": id,
 		},

--- a/cli/cmd/kubernetes/job/jvm.go
+++ b/cli/cmd/kubernetes/job/jvm.go
@@ -37,7 +37,7 @@ func (c *jvmCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (string
 
 	commonMeta := metav1.ObjectMeta{
 		Name:      fmt.Sprintf("kubectl-flame-%s", id),
-		Namespace: cfg.TargetConfig.Namespace,
+		Namespace: cfg.JobConfig.Namespace,
 		Labels: map[string]string{
 			"kubectl-flame/id": id,
 		},

--- a/cli/cmd/kubernetes/job/python.go
+++ b/cli/cmd/kubernetes/job/python.go
@@ -44,7 +44,7 @@ func (p *pythonCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (str
 
 	commonMeta := metav1.ObjectMeta{
 		Name:      fmt.Sprintf("kubectl-flame-%s", id),
-		Namespace: cfg.TargetConfig.Namespace,
+		Namespace: cfg.JobConfig.Namespace,
 		Labels: map[string]string{
 			"kubectl-flame/id": id,
 		},

--- a/cli/cmd/kubernetes/job/ruby.go
+++ b/cli/cmd/kubernetes/job/ruby.go
@@ -39,7 +39,7 @@ func (r *rubyCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (strin
 
 	commonMeta := metav1.ObjectMeta{
 		Name:      fmt.Sprintf("kubectl-flame-%s", id),
-		Namespace: cfg.TargetConfig.Namespace,
+		Namespace: cfg.JobConfig.Namespace,
 		Labels: map[string]string{
 			"kubectl-flame/id": id,
 		},

--- a/cli/cmd/kubernetes/launch.go
+++ b/cli/cmd/kubernetes/launch.go
@@ -29,7 +29,7 @@ func LaunchFlameJob(targetPod *v1.Pod, cfg *data.FlameConfig, ctx context.Contex
 
 	createJob, err := clientSet.
 		BatchV1().
-		Jobs(cfg.TargetConfig.Namespace).
+		Jobs(cfg.JobConfig.Namespace).
 		Create(ctx, flameJob, metav1.CreateOptions{})
 	if err != nil {
 		return "", nil, err

--- a/cli/cmd/kubernetes/read.go
+++ b/cli/cmd/kubernetes/read.go
@@ -33,15 +33,15 @@ func GetPodDetails(podName, namespace string, ctx context.Context) (*apiv1.Pod, 
 	return podObject, nil
 }
 
-func WaitForPodStart(target *data.TargetDetails, ctx context.Context) (*apiv1.Pod, error) {
+func WaitForPodStart(cfg *data.FlameConfig, ctx context.Context) (*apiv1.Pod, error) {
 	var pod *apiv1.Pod
 	err := wait.Poll(1*time.Second, 5*time.Minute,
 		func() (bool, error) {
 			podList, err := clientSet.
 				CoreV1().
-				Pods(target.Namespace).
+				Pods(cfg.JobConfig.Namespace).
 				List(ctx, metav1.ListOptions{
-					LabelSelector: fmt.Sprintf("kubectl-flame/id=%s", target.Id),
+					LabelSelector: fmt.Sprintf("kubectl-flame/id=%s", cfg.TargetConfig.Id),
 				})
 
 			if err != nil {
@@ -75,11 +75,11 @@ func WaitForPodStart(target *data.TargetDetails, ctx context.Context) (*apiv1.Po
 func GetLogsFromPod(pod *apiv1.Pod, handler DataHandler, ctx context.Context) (chan bool, error) {
 	done := make(chan bool)
 	req := clientSet.CoreV1().
-    		Pods(pod.Namespace).
-    		GetLogs(pod.Name, &apiv1.PodLogOptions{
-    			Follow:    true,
-    			Container: job.ContainerName,
-    		})
+		Pods(pod.Namespace).
+		GetLogs(pod.Name, &apiv1.PodLogOptions{
+			Follow:    true,
+			Container: job.ContainerName,
+		})
 
 	readCloser, err := req.Stream(ctx)
 	if err != nil {

--- a/cli/cmd/logic.go
+++ b/cli/cmd/logic.go
@@ -22,7 +22,11 @@ func Flame(cfg *data.FlameConfig) {
 
 	p := NewPrinter(cfg.TargetConfig.DryRun)
 
-	cfg.TargetConfig.Namespace = ns
+	if cfg.TargetConfig.Namespace == "" {
+		cfg.TargetConfig.Namespace = ns
+	}
+	cfg.JobConfig.Namespace = ns
+
 	ctx := context.Background()
 
 	p.Print("Verifying target pod ... ")
@@ -61,7 +65,7 @@ func Flame(cfg *data.FlameConfig) {
 	}
 
 	cfg.TargetConfig.Id = profileId
-	profilerPod, err := kubernetes.WaitForPodStart(cfg.TargetConfig, ctx)
+	profilerPod, err := kubernetes.WaitForPodStart(cfg, ctx)
 	if err != nil {
 		p.PrintError()
 		log.Fatalf(err.Error())

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -19,7 +19,7 @@ const (
 	defaultEvent    = string(api.Wall)
 	flameLong       = `Profile existing applications with low-overhead by generating flame graphs.
 
-These commands help you identify application performance issues. 
+These commands help you identify application performance issues.
 `
 	flameExamples = `
 	# Profile a pod for 5 minutes and save the output as flame.svg file
@@ -106,6 +106,7 @@ func NewFlameCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&targetDetails.DryRun, "dry-run", false, "Simulate profiling")
 	cmd.Flags().StringVar(&targetDetails.Image, "image", "", "Manually choose agent docker image")
 	cmd.Flags().StringVar(&targetDetails.DockerPath, "docker-path", "/var/lib/docker/", "Use a different Docker install path")
+	cmd.Flags().StringVar(&targetDetails.Namespace, "target-namespace", "", "namespace of target pod if differnt from job namespace")
 	cmd.Flags().StringVarP(&targetDetails.Pgrep, "pgrep", "p", "", "name of the target process")
 
 	cmd.Flags().StringVarP(&chosenLang, "lang", "l", "", fmt.Sprintf("Programming language of "+


### PR DESCRIPTION
Currently, job deployment is assumed to be in the same namespace as the
targetted pod. When utilizing bpf tracing, for example, a privileged
pod may be required. In many situations, namespaces have security
restrictions preventing them from scheduling privileged pods.

This commit adds an optional argument `target-namespace` to allow
selecting pods from an unprivileged namespace.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
