### PR TITLE
feat: use CPU as default event

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultDuration = 1 * time.Minute
-	defaultEvent    = string(api.Wall)
+	defaultEvent    = string(api.Cpu)
 	flameLong       = `Profile existing applications with low-overhead by generating flame graphs.
 
 These commands help you identify application performance issues. 


### PR DESCRIPTION
Switch default profiling event to CPU, fixes #63

The default profiling event is the same for all languages, if it causes an issue to switch to CPU to all languages I can only switch it for Java as suggested in the issue.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
