### PR TITLE
fix: add containerd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ kubectl flame mypod -t 1m --lang go -f /tmp/flamegraph.svg --pgrep go-app
 ```
 Java profiling assumes that the process name is `java`. Use `--pgrep` flag if your process name is different.
 
+### Profiling on clusters running containerd
+
+To run this tool on Kubernetes clusters that use containerd as the runtime engine, you must specify the path to the containerd runtime files:
+
+```shell
+kubectl flame mypod -t 1m --docker-path /run/containerd
+```
+
 ## Installing
 
 ### Krew

--- a/agent/utils/filesystem.go
+++ b/agent/utils/filesystem.go
@@ -1,17 +1,36 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"strings"
 )
 
 const (
-	mountIdLocation          = "/var/lib/docker/image/overlay2/layerdb/mounts/%s/mount-id"
-	targetFileSystemLocation = "/var/lib/docker/overlay2/%s/merged"
+	overlayFsMountIdLocation = "/var/lib/docker/image/overlay2/layerdb/mounts/%s/mount-id"
+	// The actual path on the host is /run/containerd/io... but we don't change the path within the agent to not break backwards compatibility with the flag
+	containerdMountIdLocation = "/var/lib/docker/io.containerd.runtime.v2.task/k8s.io/%s/rootfs"
+	targetFileSystemLocation  = "/var/lib/docker/overlay2/%s/merged"
 )
 
 func GetTargetFileSystemLocation(containerId string) (string, error) {
-	fileName := fmt.Sprintf(mountIdLocation, containerId)
+	fileName := fmt.Sprintf(overlayFsMountIdLocation, containerId)
+
+	// Check if the node uses overlayfs mount location
+	if _, err := os.Stat(fileName); errors.Is(err, os.ErrNotExist) {
+		// retry with containerd path
+		// remove containerd:// prefix if necessary
+		containerIdSanitized := strings.Replace(containerId, "containerd://", "", 1)
+		fileName = fmt.Sprintf(containerdMountIdLocation, containerIdSanitized)
+		_, err := os.Stat(fileName)
+		if err == nil {
+			// file exists, must be a containerd node
+			// the path here is already the rootfs of the container, can return immediately
+			return fileName, nil
+		}
+	}
 	mountId, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This is a very simple fix/workaround for allowing profiling on clusters that use containerd as the container runtime.

The user has to provide the "docker-path" as the containerd runtime path.

There are of course more direct approaches to this, but this is the one that requires the least change in the current codebase. (also, the name `docker-path` becomes a bit meaningless)

tested this new agent image to be working on both dockerd clusters + containerd clusters.

let me know what you think, if necessary i can also adapt the implementation a bit.

closes #69 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
