### PR TITLE
Specify job namespace instead of target namespace after https://github.com/yahoo/kubectl-flame/pull/64

### DIFF
--- a/cli/cmd/kubernetes/launch.go
+++ b/cli/cmd/kubernetes/launch.go
@@ -50,7 +50,7 @@ func DeleteProfilingJob(job *batchv1.Job, targetDetails *data.TargetDetails, ctx
 	deleteStrategy := metav1.DeletePropagationForeground
 	return clientSet.
 		BatchV1().
-		Jobs(targetDetails.Namespace).
+		Jobs(job.Namespace).
 		Delete(ctx, job.Name, metav1.DeleteOptions{
 			PropagationPolicy: &deleteStrategy,
 		})


### PR DESCRIPTION
Otherwise it silently fails, attempting deleting the job from the target namespace.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
