### PR TITLE
fix: add missing - to cpu and memory request and limit example cmd

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -32,7 +32,7 @@ These commands help you identify application performance issues.
 	%[1]s flame mypod -f /tmp/flame.svg -n test container1
 
 	# Set custom resource requests and limits for the kubectl-flame pod (default: neither requests nor limits are set)
-	%[1]s flame mypod -f flame.svg -cpu.requests 100m -cpu.limits 200m -mem.requests 100Mi -mem.limits 200Mi
+	%[1]s flame mypod -f flame.svg --cpu.requests 100m --cpu.limits 200m --mem.requests 100Mi --mem.limits 200Mi
 `
 )
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

add missing - to cpu and memory request and limit example cmd
See: 
```
Profile existing applications with low-overhead by generating flame graphs.

These commands help you identify application performance issues.

Usage:
  flame [pod-name]

Examples:

	# Profile a pod for 5 minutes and save the output as flame.svg file
	kubectl flame mypod -f flame.svg -t 5m

	# Profile an alpine based container
	kubectl flame mypod -f flame.svg --alpine

	# Profile specific container container1 from pod mypod in namespace test
	kubectl flame mypod -f /tmp/flame.svg -n test container1

	# Set custom resource requests and limits for the kubectl-flame pod (default: neither requests nor limits are set)
	kubectl flame mypod -f flame.svg -cpu.requests 100m -cpu.limits 200m -mem.requests 100Mi -mem.limits 200Mi

Flags:
      --alpine                         Target image is based on Alpine
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default HTTP cache directory (default "/Users/windy/.kube/http-cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --cpu.limits string              CPU limits of the started profiling container
      --cpu.requests string            CPU requests of the started profiling container
      --docker-path string             Use a different Docker install path (default "/var/lib/docker/")
      --dry-run                        Simulate profiling
  -e, --event string                   Profiling event, choose one of [cpu alloc lock cache-misses wall itimer] (default "cpu")
  -f, --file string                    Optional file location (default "flamegraph.svg")
  -h, --help                           help for flame
      --image string                   Manually choose agent docker image
      --imagePullSecret string         imagePullSecret for agent docker image
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -l, --lang string                    Programming language of the target application, choose one of [java go python ruby node]
      --mem.limits string              Memory limits of the started profiling container
      --mem.requests string            Memory requests of the started profiling container
  -n, --namespace string               If present, the namespace scope for this CLI request
  -p, --pgrep string                   name of the target process
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --serviceAccountName string      serviceAccountName to be used for profiling container
      --target-namespace string        namespace of target pod if differnt from job namespace
  -t, --time duration                  Max scan Duration (default 1m0s)
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --version                        Print version info
```